### PR TITLE
Inject Logger

### DIFF
--- a/default/cmd/server/main.go
+++ b/default/cmd/server/main.go
@@ -62,7 +62,7 @@ func main() {
 	}
 
 	logger.Debug().Str("service", "{{.ServiceName}}").Msg("creating server")
-	server, err := methods.New{{.GoServiceName}}Server()
+	server, err := methods.New{{.GoServiceName}}Server(logger)
 	if err != nil {
 		logger.Fatal().AnErr("New{{.GoServiceName}}Server())", err).Msg("")
 	}

--- a/default/cmd/server/methods/new_server.go
+++ b/default/cmd/server/methods/new_server.go
@@ -1,13 +1,18 @@
 package {{.MethodsPackageName}}
 
 import (
+	
+	"github.com/rs/zerolog"
 	pb "{{.PBImport}}"
 )
 
 type serverData struct{
+	zerolog.Logger
 }
 
 // New{{.GoServiceName}}Server returns an object that implements the pb.{{.GoServiceName}}Server interface
-func New{{.GoServiceName}}Server() (pb.{{.GoServiceName}}Server, error) {
-	return &serverData{}, nil
+func New{{.GoServiceName}}Server(logger zerolog.Logger) (pb.{{.GoServiceName}}Server, error) {
+	return &serverData{
+		logger,
+	}, nil
 }


### PR DESCRIPTION
Now a user can access the zerolog logger object methods through the server object.

Example:
```go
func (s *serverData) CreateCategory(ctx context.Context, request *pb.Category) (*pb.Category, error) {
	dn, err := s.FetchUserDN(ctx)
	if err != nil {
		return nil, err
	}

	chck := util.DiasCheck(dn)
	if !chck.Success {
		s.Error().Msg(chck.Message)
		return nil, errors.New(chck.Message)
	}

	// set things that need to be set for db
	request.Id = dbutil.CreateHash()
	request.CreatedAt = time.Now().Format(time.RFC3339)

	b, err := json.Marshal(request)
	if err != nil {
		s.Error().Err(err).Msg("failed to marshal category")
		return nil, err
	}

	err = s.Client.Set("C:"+request.Id, b, 0).Err()
	if err != nil {
		s.Error().Err(err).Msg("failed to set category in redis")
		return nil, err
	}

	return request, nil
}
```
I've had a few requests for this and have actually done it myself in the services I've written with the generator.

closes #18 