### PR TITLE
ZooKeeper connection string 

### DIFF
--- a/default/templates/cmd/server/zk.go
+++ b/default/templates/cmd/server/zk.go
@@ -21,8 +21,10 @@ func notifyZkOfMetricsIfNeeded(logger zerolog.Logger) ([]zkCancelFunc, error) {
 		return nil, err
 	}
 
+	zk_servers := strings.Split(viper.GetString("zk_connection_string"), ",")
+
 	logger.Info().Str("service", "{{.ServiceName}}").Msg("announcing metrics endpoint to zookeeper")
-	cancel := gk.Announce(parseConnectionString(), &gk.Registration{
+	cancel := gk.Announce(zk_servers, &gk.Registration{
 		Path:   viper.GetString("zk_announce_path") + viper.GetString("metrics_dashboard_uri_path"),
 		Host:   host,
 		Status: gk.Alive,
@@ -43,8 +45,10 @@ func notifyZkOfRPCServerIfNeeded(logger zerolog.Logger) ([]zkCancelFunc, error) 
 		return nil, err
 	}
 
+	zk_servers := strings.Split(viper.GetString("zk_connection_string"), ",")
+
 	logger.Info().Str("service", "{{.ServiceName}}").Msg("announcing rpc endpoint to zookeeper")
-	cancel := gk.Announce(parseConnectionString(), &gk.Registration{
+	cancel := gk.Announce(zk_servers, &gk.Registration{
 		Path:   viper.GetString("zk_announce_path") + "/rpc",
 		Host:   host,
 		Status: gk.Alive,
@@ -70,9 +74,11 @@ func notifyZkOfGatewayEndpointIfNeeded(logger zerolog.Logger) ([]zkCancelFunc, e
 		gatewayEndpoint = "https"
 	}
 
+	zk_servers := strings.Split(viper.GetString("zk_connection_string"), ",")
+
 	logger.Info().Str("service", "{{.ServiceName}}").Msg("announcing gateway endpoint to zookeeper")
 
-	cancel := gk.Announce(parseConnectionString(), &gk.Registration{
+	cancel := gk.Announce(zk_servers, &gk.Registration{
 		Path:   viper.GetString("zk_announce_path") + "/" + gatewayEndpoint,
 		Host:   host,
 		Status: gk.Alive,
@@ -81,10 +87,6 @@ func notifyZkOfGatewayEndpointIfNeeded(logger zerolog.Logger) ([]zkCancelFunc, e
 	logger.Info().Str("service", "{{.ServiceName}}").Msg("announcing gateway endpoint to zookeeper")
 
 	return []zkCancelFunc{cancel}, nil
-}
-
-func parseConnectionString() []string {
-	return strings.Split(viper.GetString("zk_connection_string"), ",")
 }
 
 func checkAnnounceHost(ah string, logger zerolog.Logger) (string, error) {

--- a/default/templates/cmd/server/zk.go
+++ b/default/templates/cmd/server/zk.go
@@ -1,6 +1,8 @@
 package main
 
 import (
+	"strings"
+
 	"github.com/rs/zerolog"
 	"github.com/spf13/viper"
 
@@ -20,7 +22,7 @@ func notifyZkOfMetricsIfNeeded(logger zerolog.Logger) ([]zkCancelFunc, error) {
 	}
 
 	logger.Info().Str("service", "{{.ServiceName}}").Msg("announcing metrics endpoint to zookeeper")
-	cancel := gk.Announce(viper.GetStringSlice("zk_connection_string"), &gk.Registration{
+	cancel := gk.Announce(parseConnectionString(), &gk.Registration{
 		Path:   viper.GetString("zk_announce_path") + viper.GetString("metrics_dashboard_uri_path"),
 		Host:   host,
 		Status: gk.Alive,
@@ -42,7 +44,7 @@ func notifyZkOfRPCServerIfNeeded(logger zerolog.Logger) ([]zkCancelFunc, error) 
 	}
 
 	logger.Info().Str("service", "{{.ServiceName}}").Msg("announcing rpc endpoint to zookeeper")
-	cancel := gk.Announce(viper.GetStringSlice("zk_connection_string"), &gk.Registration{
+	cancel := gk.Announce(parseConnectionString(), &gk.Registration{
 		Path:   viper.GetString("zk_announce_path") + "/rpc",
 		Host:   host,
 		Status: gk.Alive,
@@ -70,7 +72,7 @@ func notifyZkOfGatewayEndpointIfNeeded(logger zerolog.Logger) ([]zkCancelFunc, e
 
 	logger.Info().Str("service", "{{.ServiceName}}").Msg("announcing gateway endpoint to zookeeper")
 
-	cancel := gk.Announce(viper.GetStringSlice("zk_connection_string"), &gk.Registration{
+	cancel := gk.Announce(parseConnectionString(), &gk.Registration{
 		Path:   viper.GetString("zk_announce_path") + "/" + gatewayEndpoint,
 		Host:   host,
 		Status: gk.Alive,
@@ -79,6 +81,10 @@ func notifyZkOfGatewayEndpointIfNeeded(logger zerolog.Logger) ([]zkCancelFunc, e
 	logger.Info().Str("service", "{{.ServiceName}}").Msg("announcing gateway endpoint to zookeeper")
 
 	return []zkCancelFunc{cancel}, nil
+}
+
+func parseConnectionString() []string {
+	return strings.Split(viper.GetString("zk_connection_string"), ",")
 }
 
 func checkAnnounceHost(ah string, logger zerolog.Logger) (string, error) {


### PR DESCRIPTION
is typically defined as a comma separaed list in the form ip[:port][,ip:[port]]....

closes #35 