### PR TITLE
gateway_use_tls not use_tls

### DIFF
--- a/default/templates/cmd/server/zk.go
+++ b/default/templates/cmd/server/zk.go
@@ -70,7 +70,7 @@ func notifyZkOfGatewayEndpointIfNeeded(logger zerolog.Logger) ([]zkCancelFunc, e
 	}
 
 	gatewayEndpoint := "http"
-	if viper.GetBool("use_tls") {
+	if viper.GetBool("gateway_use_tls") {
 		gatewayEndpoint = "https"
 	}
 


### PR DESCRIPTION
`gateway_use_tls` is in the example `settings.toml`; `use_tls` is not: 
if `gateway_use_tls` is set `true`, it will not take affect as the code is expecting `use_tls = true`